### PR TITLE
added HSTS header to database

### DIFF
--- a/program/databases/db_headers
+++ b/program/databases/db_headers
@@ -52,6 +52,7 @@
 "retry-after"
 "server"
 "set-cookie"
+"strict-transport-security"
 "te"
 "trailer"
 "transfer-encoding"


### PR DESCRIPTION
Many sites started to implement [HTTP Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security), but Nikto reports it as the following:

```
+ Uncommon header 'strict-transport-security' found, with contents: max-age=31536000; includeSubDomains
```

I added the HTTP header to the appropriate database file, which silences this false positive.
