### PR TITLE
Realm for Wireless-N ADSL2+ Gateway WAG160N

### DIFF
--- a/program/databases/db_realms
+++ b/program/databases/db_realms
@@ -168,3 +168,4 @@
 "700151","Topaz Site Realm","admin","admin","Mercury Interactive Topaz administrator"
 "700152","UpgradeAdministrator","admin","ncr","NCR's Terradata server, Parallel Upgrade Tool (PUT)"
 "700153","@ANY","manager","manager","3com switch"
+"700154","Linksys WAG160N ","","admin","Wireless-N ADSL2+ Gateway WAG160N"


### PR DESCRIPTION
Yes, the extra 'ending' space charter is needed in the realm!
