### PR TITLE
DEBUG Verb False Positive Fix

### DIFF
--- a/program/plugins/nikto_httpoptions.plugin
+++ b/program/plugins/nikto_httpoptions.plugin
@@ -102,9 +102,12 @@ sub nikto_httpoptions {
     # Check for other weirdness
     # IIS Debug
     return if $mark->{'terminate'};
-    ($res, $content, $error, $request, $response) = nfetch($mark, "/", "DEBUG", "", "", "", "httpoptions: DEBUG");
-    if ($res == 200) {
-        add_vulnerability($mark, "DEBUG HTTP verb may show server debugging information. See http://msdn.microsoft.com/en-us/library/e8z01xdh%28VS.80%29.aspx for details.", 999972, 0, "DEBUG", $request, $response);
+    ($res1, $content, $error, $request, $response) = nfetch($mark, "/", "GARBAGE-HEADER", "", "", "", "httpoptions: GARBAGE-HEADER");
+    if ($res1 != 200) {
+        ($res2, $content, $error, $request, $response) = nfetch($mark, "/", "DEBUG", "", "", "", "httpoptions: DEBUG");
+        if ($res2 == 200) {
+            add_vulnerability($mark, "DEBUG HTTP verb may show server debugging information. See http://msdn.microsoft.com/en-us/library/e8z01xdh%28VS.80%29.aspx for details.", 999972, 0, "DEBUG", $request, $response);
+        }
     }
 
     # IIS PROPFIND HEADER


### PR DESCRIPTION
This fixes the DEBUG Verb False Positive reported in Issue #79. 

This has been tested against a server where the False Positive is reported, it has not been tested against a server that actually has the DEBUG method enabled, so a False Negative condition may be possible as it is untested in this scenario.
