### PR TITLE
Provide start_time to port_check and nfetch.

### DIFF
--- a/program/nikto.pl
+++ b/program/nikto.pl
@@ -105,7 +105,7 @@ foreach my $mark (@MARKS) {
 
     # Check that the port is open
     my $open =
-      port_check($mark->{'hostname'}, $mark->{'ip'}, $mark->{'port'}, $CLI{'key'}, $CLI{'cert'});
+      port_check(time(), $mark->{'hostname'}, $mark->{'ip'}, $mark->{'port'}, $CLI{'key'}, $CLI{'cert'});
     if (defined $CLI{'vhost'}) { $mark->{'vhost'} = $CLI{'vhost'} }
     if ($open == 0) {
         $mark->{'test'} = 0;

--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1424,7 +1424,7 @@ sub count_fields {
 
 ###############################################################################
 sub port_check {
-    my ($hostname, $ip, $port, $key, $cert) = @_;
+    my ($start_time, $hostname, $ip, $port, $key, $cert) = @_;
     my $m = {};
 
     # Check SKIPPORTS
@@ -1433,6 +1433,7 @@ sub port_check {
         return 0;
     }
 
+    $m->{start_time} = $start_time;
     $m->{hostname} = $hostname;
     $m->{ip}       = $ip;
     $m->{port}     = $port;


### PR DESCRIPTION
Prevent "ERROR: Host maximum execution time of 43200 seconds reached" when using -maxtime by providing a start_time to port_check. Issue #90 #91
