### PR TITLE
Adding a check for the c99 remote shell

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6703,3 +6703,5 @@
 "006734","0","0","/cqresource/","GET","200","","","","","CRX WebDAV upload","",""
 "006735","0","3","/etc/cloudservices","GET","200","","","","","Adobe Experience Manager Cloud Service Information","",""
 "006736","0","3","/etc/reports","GET","200","","","","","Adobe Experience Manager Reports","",""
+"006737","0","8b","@CGIDIRSc99.php","GET","200","","r57 c99 shell","","","c99.php remote web shell","",""
+"006738","0","8b","/c99.php","GET","200","","r57 c99 shell","","","c99.php remote web shell","",""


### PR DESCRIPTION
Checks for the c99 remote web shell based off the default c99 filename.
