### PR TITLE
Dirty hack to resolve issue #104

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -641,6 +641,11 @@ sub general_config {
             nprint("+ ERROR: -Save must have a directory name or '.' for auto-generated");
             exit;
         }
+        eval "require JSON::PP";
+        if ($@) {
+            nprint("+ ERROR: Module JSON::PP missing.");
+            exit;
+        }
     }
 
     # port(s)


### PR DESCRIPTION
I opted to do it this way as the existing check for JSON::PP does not execute until after nikto has run, it would probably make more sense to rework the core plugin to include a dependency checker function that can be called at the opt parse stage.
