### PR TITLE
Enable the text reporting plugin if plugin @@NONE is used.

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1541,7 +1541,9 @@ sub load_plugins {
 
     # Check if running plugins is NONE - if so, don't bother initalising plugins
     if ($CLI{'plugins'} eq '@@NONE') {
-        return;
+        # return;
+        # enable text reporting by default
+        $CLI{'plugins'} = 'report_text';
     }
 
     foreach my $plugin (@pluginlist) {


### PR DESCRIPTION
Lazy attempt at solving issue #88.
Not sure if it's ideall though as it changes the number of tests performed:

```
root@bt:~/nikto/program# ./nikto.pl -Plugins '@@NONE' -host localhost
- Nikto v2.1.6
---------------------------------------------------------------------------
+ Server: Apache
+ 2 requests: 0 error(s) and 0 item(s) reported on remote host
+ End Time:           2014-07-14 00:01:38 (GMT-4) (0 seconds)
---------------------------------------------------------------------------
+ 1 host(s) tested
root@bt:~/nikto/program# vim plugins/nikto_core.plugin
root@bt:~/nikto/program# ./nikto.pl -Plugins '@@NONE' -host localhost
- Nikto v2.1.6
---------------------------------------------------------------------------
+ Target IP:          127.0.0.1
+ Target Hostname:    localhost
+ Target Port:        80
+ Start Time:         2014-07-14 00:02:59 (GMT-4)
---------------------------------------------------------------------------
+ Server: Apache
+ 210 requests: 0 error(s) and 0 item(s) reported on remote host
+ End Time:           2014-07-14 00:03:00 (GMT-4) (1 seconds)
---------------------------------------------------------------------------
+ 1 host(s) tested
```
