### PR TITLE
Added check for Cisco ASA info leak

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6941,3 +6941,4 @@
 "006981","0","3","/paypal/ipn_log.txt","GET","payer_email","","","","","PayPal log file found and may contain sensitive information.","",""
 "006983","0","3","/psystems/paypal/ipn_log.txt","GET","payer_email","","","","","PayPal log file found and may contain sensitive information.","",""
 "006984","0","3be","/_profile/","GET","symfony","No\sroute","","","","Symfony Profiler may reveal sensitive application information.","",""
+"006985","0","3b","/CSCOSSLC/config-auth","GET","<version who(.*)>([0-9.()]+)</version>","","","","","Cisco ASA Web VPN may reval sensitive version infos (CVE-2014-3398).","",""


### PR DESCRIPTION
See: http://carnal0wnage.attackresearch.com/2015/02/cisco-asa-version-grabber-cve-2014-3398.html