### PR TITLE
Added version check for Jetleak (2015-2080)

### DIFF
--- a/program/databases/db_outdated
+++ b/program/databases/db_outdated
@@ -1285,3 +1285,4 @@
 "601272","mod_security/","1.8.7","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "601273","mod_suid/","1.1","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "601274","srp/","2.c","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
+"601275","Jetty","Jetty(9.2.10-v20150310)","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER). Jetty 8.1.16.v20140903 and 7.6.16.v20140903 are also current."

--- a/program/databases/db_server_msgs
+++ b/program/databases/db_server_msgs
@@ -276,3 +276,4 @@
 "800256","cpservd","0","This is a web hosting manager. It should not be running unless required, as it allows web server administration."
 "800257","mod_speling","0","mod_speling can reveal otherwise hidden files via 'misspelled' file names."
 "800259","HttpFileServer\shttpd","0","This server has been known to host malware, see: https://pronto185.com/blog/2014/03/06/slightly-interesting-find-from-sshranking/"
+"800260","Jetty\(9\.2\.[3-8].*","118744","Jetty 9.2.3 to 9.2.8 contains a flaw that is triggered when handling 400 errors in HTTP responses. This may allow a remote attacker to gain access to potentially sensitive information in the memory (CVE-2015-2080)."


### PR DESCRIPTION
Currently only an banner based test. If its possible to send an non-valid ASCII char (See [1]) in the Referer: header of Nikto i could also do an active check.

[1] http://blog.gdssecurity.com/labs/2015/2/25/jetleak-vulnerability-remote-leakage-of-shared-buffers-in-je.html