### PR TITLE
Added header X-Mod-Pagespeed

### DIFF
--- a/program/databases/db_headers
+++ b/program/databases/db_headers
@@ -97,6 +97,7 @@
 "x-content-security-policy"
 "x-webkit-csp"
 "x-aspnetmvc-version"
+"x-mod-pagespeed"
 "access-control-expose-headers"
 "access-control-allow-methods"
 "access-control-allow-headers"

--- a/program/plugins/nikto_headers.plugin
+++ b/program/plugins/nikto_headers.plugin
@@ -61,11 +61,12 @@ sub nikto_headers_postfetch {
     # look for internal IPs
     foreach my $header (keys %$result) {
         # skip some very unlikely headers
-        if    ($header eq 'whisker')        { next; }
-        elsif ($header eq 'date')           { next; }
-        elsif ($header eq 'content-type')   { next; }
-        elsif ($header eq 'content-length') { next; }
-        elsif ($header eq 'connection')     { next; }
+        if    ($header eq 'whisker')         { next; }
+        elsif ($header eq 'date')            { next; }
+        elsif ($header eq 'content-type')    { next; }
+        elsif ($header eq 'content-length')  { next; }
+        elsif ($header eq 'connection')      { next; }
+        elsif ($header eq 'x-mod-pagespeed') { next; }
 	elsif (defined $HFOUND{$header})    { next; }
         foreach my $ip (get_ips($result->{$header})) {
             my ($valid, $internal, $loopback) = is_ip($ip);


### PR DESCRIPTION
This header contains the version number of Google's [PageSpeed Module](https://developers.google.com/speed/pagespeed/module), and it's
 - recognized as an uncommon header and
 - the version number is falsely recognized as an IP address.

Here's an example:

    + IP address found in the 'x-mod-pagespeed' header. The IP is "1.7.30.4".
    + Uncommon header 'x-mod-pagespeed' found, with contents: 1.7.30.4-3847

This patch solves these problems one commit at a time. Note: `nikto_headers.plugin` had only one non-whitespace line addition, use `-w` along with `git show` or `git diff` to ignore the indentation fixup.