### PR TITLE
Update PHP versions (fixes #252)

### DIFF
--- a/program/databases/db_outdated
+++ b/program/databases/db_outdated
@@ -639,7 +639,7 @@
 "600622","PEWG/","1.2","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600623","Phantom/","2.2.1","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600624","PHP-CGI/","0.9","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
-"600625","PHP/","5.6.2","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER). PHP 5.5.18, 5.4.34 and 5.3.29 are also current."
+"600625","PHP/","5.6.9","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER). PHP 5.5.25 and 5.4.41 are also current."
 "600626","PHP/FI-","2.0","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600627","PI/","7.5","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600628","Pi3Web/","2.0.3","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"


### PR DESCRIPTION
Also removed PHP 5.3 as this branch has reached EOL in August 2014:

https://php.net/eol.php