### PR TITLE
Add --dbcheck for wrong used slash after @VARIABLE

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1297,18 +1297,22 @@ sub check_dbs {
                     if ($bad) { nprint("\t+ ERROR: Invalid regex in field $i: \"$L[$i]\", line: $line"); }
                 }
                 if (($L[0] ne 0) && exists($ALL_IDS{$L[0]})) {
-                        nprint("\t+ ERROR: Duplicate Test ID: $L[0]");
+                    nprint("\t+ ERROR: Duplicate Test ID: $L[0]");
                 }
-                else { 
-			$ALL_IDS{$L[0]}=1; 
-		}
+                else {
+                    $ALL_IDS{$L[0]}=1;
+                }
                 if ($L[2] =~ /[^a-e0-9]/) {
-			nprint("\t+ ERROR: Invalid Tuning Type: $line");
-		}
-		if ($L[3] =~ '^(/@|//)' && $L[0] !~ /(000396|000447|000543|000544|000545|000928|000929|001208|001373|001497|002761|002762|003029)/i) {
-			nprint("\t+ ERROR: Possible incorrect slashes: $line");
-			nprint("\t+ If two or more slashes are needed for this test: Please add the ID $L[0] at line " . (__LINE__-2) . " in the nikto_core.plugin.");
-		}
+                    nprint("\t+ ERROR: Invalid Tuning Type: $line");
+                }
+                if ($L[3] =~ '^(/@|//)' && $L[0] !~ /(000396|000447|000543|000544|000545|000928|000929|001208|001373|001497|002761|002762|003029)/i) {
+                    nprint("\t+ ERROR: Possible incorrect slashes: $line");
+                    nprint("\t+ If two or more slashes are needed for this test: Please add the ID $L[0] at line " . (__LINE__-2) . " in the nikto_core.plugin.");
+                }
+                if ($L[3] =~ '^@[A-Z]+/' && $L[0] !~ /(003348|003349)/i) {
+                    nprint("\t+ ERROR: Possible incorrect slash after \@VARIABLE: $line");
+                    nprint("\t+ If this slash is needed for this test: Please add the ID $L[0] at line " . (__LINE__-2) . " in the nikto_core.plugin.");
+                }
                 if ((($L[4] ne 'POST') && ($L[4] ne 'SEARCH')) && ($L[11] ne '')) {
                     # Some test IDs need this
                     if ($L[0] !~ /(006992|000126|000291|001153)/i) {


### PR DESCRIPTION
The check could have catched: https://github.com/sullo/nikto/pull/257

Not quite sure about the 003348 and 003349 tests so i'm excluding them for now.

Also changed tabs to spaces in the other two checks and fixed the indent.