### PR TITLE
Update XML output template format

### DIFF
--- a/program/templates/xml_end.tmpl
+++ b/program/templates/xml_end.tmpl
@@ -1,2 +1,4 @@
 <statistics elapsed="#TEMPL_ELAPSED#" itemsfound="#TEMPL_ITEMS_FOUND#" itemstested="#TEMPL_ITEMS_TESTED#" endtime="#TEMPL_END#" />
-</scandetails></niktoscan>
+</scandetails>
+
+</niktoscan>

--- a/program/templates/xml_end.tmpl
+++ b/program/templates/xml_end.tmpl
@@ -1,2 +1,2 @@
 <statistics elapsed="#TEMPL_ELAPSED#" itemsfound="#TEMPL_ITEMS_FOUND#" itemstested="#TEMPL_ITEMS_TESTED#" endtime="#TEMPL_END#" />
-</scandetails>
+</scandetails></niktoscan>

--- a/program/templates/xml_start.tmpl
+++ b/program/templates/xml_start.tmpl
@@ -1,2 +1,3 @@
 <?xml version="1.0" ?>
 <!DOCTYPE niktoscan SYSTEM "#NIKTODTD#">
+<niktoscan>


### PR DESCRIPTION
The existing XML output template does not unmarshall successfully due to orphan <niktoscan> XML tags. The current output format is similar to the following:

```
<niktoscan>
  <scandetails>
  </scandetails>
  <niktoscan>
    <scandetails>
    </scandetails>
</niktoscan>
```

I have updated the template to include a top order <niktoscan> XML tag and then to close out the sub niktoscan tag preceeding each completed scandetails section. the update would output the following format:

```
<niktoscan>
  <niktoscan>
    <scandetails>
    </scandetails>
  </niktoscan
  <niktoscan>
    <scandetails>
    </scandetails>
  </niktoscan>
</niktoscan>
```

This will unmarshall successfully.