### PR TITLE
Fix header in db_favicon.

### DIFF
--- a/program/databases/db_favicon
+++ b/program/databases/db_favicon
@@ -14,11 +14,8 @@
 # Notes:
 # NiktoDB 1.0
 # Example to get the md5hash: $ md5sum favicon.ico
-#
-# Field order:
-# Test-ID, md5hash, description
-#
 #######################################################################
+"nikto_id","md5hash","description"
 "500017","4987120f4fb1dc454f889e8c92f6dabe","Google Web Server"
 # at /platform/images/favicon.ico, see ticket 238
 "500108","c0dc2e457e05c2ce0a99886ec1048d77","Platform Computing Corporation Platform Management Console Version v2.0"

--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1273,7 +1273,7 @@ sub check_dbs {
                 $line =~ s/^\s+//;
                 if ($line =~ /^\#/) { next; }
                 chomp($line);
-                if ($line eq "") { next; }
+                if ($line eq "" || $line =~ /"nikto_id"/) { next; }
                 $counter++;
                 my @L = parse_csv($line);
                 if ($#L ne 2) { nprint("\t+ ERROR: Invalid syntax ($#L): $line"); next; }


### PR DESCRIPTION
Sorry, had broken this in https://github.com/sullo/nikto/pull/305. I wasn't aware that the first header/column is actually needed.

To avoid having an false positive within the --dbcheck the line in nikto_core.plugin is needed.