### PR TITLE
Add Ghost, Kodi, PAW server favicon

### DIFF
--- a/program/databases/db_favicon
+++ b/program/databases/db_favicon
@@ -377,3 +377,4 @@
 "500770","a4eb4e0aa80740db8d7d951b6d63b2a2","ownCloud"
 "500771","56974e6b57c7bd51448c309915ca0d6c","Ghost blog (0.7.x)"
 "500772","91b72b23e7f499d6c09cb18c7b1278f1","Kodi Media Center 16.x (Web Interface)"
+"500773","92c5d340d08c6d33676a41ba8dece857","Android PAW Server"

--- a/program/databases/db_favicon
+++ b/program/databases/db_favicon
@@ -376,3 +376,4 @@
 "500769","aa9b62c9aa50e0bc1f77061e6362d736","Apache"
 "500770","a4eb4e0aa80740db8d7d951b6d63b2a2","ownCloud"
 "500771","56974e6b57c7bd51448c309915ca0d6c","Ghost blog (0.7.x)"
+"500772","91b72b23e7f499d6c09cb18c7b1278f1","Kodi Media Center 16.x (Web Interface)"

--- a/program/databases/db_favicon
+++ b/program/databases/db_favicon
@@ -375,3 +375,4 @@
 "500768","07e9163f7ca8cfe6c1d773f895fbebad","Apache"
 "500769","aa9b62c9aa50e0bc1f77061e6362d736","Apache"
 "500770","a4eb4e0aa80740db8d7d951b6d63b2a2","ownCloud"
+"500771","56974e6b57c7bd51448c309915ca0d6c","Ghost blog (0.7.x)"


### PR DESCRIPTION
**1. Ghost blog favicon**
Ghost blog favicon was updated about 3 yrs ago.

[GitHub history of Ghost blog favicon](https://github.com/TryGhost/Ghost/commits/8808674bbddca93e57d849ddb0a12700571bcd8a/core/shared/favicon.ico)

**2. Kodi Media Center favicon**
Kodi Media Center favicon was updated about 2 yrs ago.

[GitHub history of Kodi Media Center favicon](https://github.com/xbmc/xbmc/commits/f303c86db9a8bb11dd27983dca64235ad3f95a55/addons/webinterface.default/favicon.ico)

**3. PAW Server for Android favicon**
