### PR TITLE
Updated RFI url

### DIFF
--- a/program/nikto.conf
+++ b/program/nikto.conf
@@ -17,7 +17,7 @@ USERAGENT=Mozilla/5.00 (Nikto/@VERSION) (Evasions:@EVASIONS) (Test:@TESTID)
 
 # RFI URL. This remote file should return a phpinfo call, for example: <?php phpinfo(); ?>
 # You may use the one below, if you like.
-RFIURL=http://cirt.net/rfiinc.txt?
+RFIURL=https://cirt.net/rfiinc.txt?
 
 # IDs never to alert on (Note: this only works for IDs loaded from db_tests)
 #SKIPIDS=


### PR DESCRIPTION
The current one is getting a redirect:

```
curl -i http://cirt.net/rfiinc.txt?
HTTP/1.1 302 Found
Date: Fri, 20 May 2016 08:28:23 GMT
Server: Apache
Location: https://cirt.net/rfiinc.txt?
Vary: Accept-Encoding
Content-Length: 212
Content-Type: text/html; charset=iso-8859-1

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://cirt.net/rfiinc.txt?">here</a>.</p>
</body></html>
```