### PR TITLE
Added Drupal CHANGELOG.txt for 8.x

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6814,3 +6814,4 @@
 "007117","0","1","/composer.json","GET","\"name\":","","","","","Composer Dependency Manager for PHP information found. See https://getcomposer.org/.","",""
 "007118","0","1","/composer.lock","GET","getcomposer.org","","","","","Composer Dependency Manager for PHP lock file found. See https://getcomposer.org/.","",""
 "007119","0","3","/core/modules/config/config.info.yml","GET","version:","","","","","Drupal version number revealed in config.info.yml","",""
+"007120","0","3","/core/CHANGELOG.txt","GET","Drupal\s","","","","","Drupal version number revealed in CHANGELOG.txt","",""


### PR DESCRIPTION
Follow up of https://github.com/sullo/nikto/commit/d6be53bc9306fef695b5abfa5d2896ad7f6b10b1 with the new location of the Drupal CHANGELOG.txt (previously it was located in "/").