### PR TITLE
Fix unintended change of data in nikto_subdomain plugin

### DIFF
--- a/program/plugins/nikto_subdomain.plugin
+++ b/program/plugins/nikto_subdomain.plugin
@@ -70,6 +70,7 @@ sub nikto_subdomain {
             add_vulnerability($mark, "Subdomain $item->{'subdomain'} found", $item->{'nikto_id'}, 0, "GET", "/", $request, $response);
         }
 
+        $mark->{'hostname'} = $host;
     }    # End foreach
 }    # End sub
 


### PR DESCRIPTION
Running nikto with `-Pl @@ALL` option cause requests to wrong subdomain because nikto_subdomain plugin changes shared data.