### PR TITLE
WebSEAL version numbers are not IP addresses

### DIFF
--- a/program/plugins/nikto_headers.plugin
+++ b/program/plugins/nikto_headers.plugin
@@ -72,7 +72,7 @@ sub nikto_headers_postfetch {
         elsif ($header eq 'x-page-speed')    { next; }
         elsif (defined $HFOUND{$header}) { next; }
 	
-	next if ($header eq 'server' && substr($result->{$header}, 0, 8) eq 'WebSEAL/');
+	next if $header eq 'server' && substr($result->{$header}, 0, 8) eq 'WebSEAL/';
 
         foreach my $ip (get_ips($result->{$header})) {
             my ($valid, $internal, $loopback) = is_ip($ip);

--- a/program/plugins/nikto_headers.plugin
+++ b/program/plugins/nikto_headers.plugin
@@ -71,6 +71,8 @@ sub nikto_headers_postfetch {
         elsif ($header eq 'x-mod-pagespeed') { next; }
         elsif ($header eq 'x-page-speed')    { next; }
         elsif (defined $HFOUND{$header}) { next; }
+	
+	if ($header eq 'server' && substr($result->{$header}, 0, 8) eq 'WebSEAL/') { next; }
 
         foreach my $ip (get_ips($result->{$header})) {
             my ($valid, $internal, $loopback) = is_ip($ip);

--- a/program/plugins/nikto_headers.plugin
+++ b/program/plugins/nikto_headers.plugin
@@ -72,7 +72,7 @@ sub nikto_headers_postfetch {
         elsif ($header eq 'x-page-speed')    { next; }
         elsif (defined $HFOUND{$header}) { next; }
 	
-	if ($header eq 'server' && substr($result->{$header}, 0, 8) eq 'WebSEAL/') { next; }
+	next if ($header eq 'server' && substr($result->{$header}, 0, 8) eq 'WebSEAL/');
 
         foreach my $ip (get_ips($result->{$header})) {
             my ($valid, $internal, $loopback) = is_ip($ip);


### PR DESCRIPTION
In case of [WebSEAL](https://stackoverflow.com/tags/webseal/info) servers, the `Server` header contains the version number, which happens to contain four single-digit parts, resulting in the followin lines being printed during a scan.

    + Server: WebSEAL/8.0.1.3
    + IP address found in the 'server' header. The IP is "8.0.1.3".

This patch ignores `Server` headers that start with `WebSEAL/` when looking for IP addresses.