### PR TITLE
Add Alzip archive extensions

### DIFF
--- a/program/plugins/nikto_sitefiles.plugin
+++ b/program/plugins/nikto_sitefiles.plugin
@@ -66,7 +66,7 @@ sub nikto_sitefiles {
 
     foreach my $item (keys %names) {
         next if $item eq '';
-        foreach my $ext (qw/jks cer pem zip tar tar.gz tgz tar.bz2 tar.lzma/) {
+        foreach my $ext (qw/jks cer pem zip tar tar.gz tgz tar.bz2 tar.lzma alz egg/) {
             $files{"$item\.$ext"} = 1;
         }
     }


### PR DESCRIPTION
I'm not sure whether it is good or not to add this feature.

Because:
Alzip is a very famous archive program in *JUST* South Korea, and some sysadmins upload site source files zipped with it.

Is it worth to sacrifice the running speed for the security of small numbers of people?
