### PR TITLE
Add .war extensions

### DIFF
--- a/program/plugins/nikto_sitefiles.plugin
+++ b/program/plugins/nikto_sitefiles.plugin
@@ -66,7 +66,7 @@ sub nikto_sitefiles {
 
     foreach my $item (keys %names) {
         next if $item eq '';
-        foreach my $ext (qw/jks cer pem zip tar tar.gz tgz tar.bz2 tar.lzma alz egg/) {
+        foreach my $ext (qw/jks cer pem zip tar tar.gz tgz tar.bz2 tar.lzma alz egg war/) {
             $files{"$item\.$ext"} = 1;
         }
     }


### PR DESCRIPTION
Some sysadmins make a mistake when they set J2EE servers up, so site main war file is exposed to the world.

With this pattern, we can detect it.