### PR TITLE
Support `=` in options

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -616,7 +616,7 @@ sub general_config {
 
     # options allows overriding of nikto.conf entries on command line
     foreach my $option (@options) {
-        my @optione=split("=", $option);
+        my @optione=split("=", $option, 2);
         $CONFIGFILE{$optione[0]}=$optione[1];
     }
 


### PR DESCRIPTION
Because of the split on the equals sign, only the value before the first `=` is
used. For example, if you have USERAGENT=aaa=bbb, the useragent should be set
to aaa=bbb and only the first `=` should be used for the split.