### PR TITLE
Add HSTS max-age=0 detection

### DIFF
--- a/program/plugins/nikto_headers.plugin
+++ b/program/plugins/nikto_headers.plugin
@@ -195,8 +195,13 @@ sub nikto_headers_postfetch {
         if (!defined $result->{'strict-transport-security'}) {
             add_vulnerability( $mark, "The site uses SSL and the Strict-Transport-Security HTTP header is not defined.", 999970, 0,
                   $request->{'whisker'}->{'method'}, $request->{'whisker'}->{'uri'}, $request, $result);
-        }
-        $HEADERS_STS{ $mark->{hostname} }{ $mark->{port} } = 1;
+        } else {
+          if ($result->{'strict-transport-security'} =~ /^max-age=0/) {
+            add_vulnerability( $mark, "The site uses SSL and the Strict-Transport-Security HTTP header is set with max-age=0.", 999970, 0,
+                  $request->{'whisker'}->{'method'}, $request->{'whisker'}->{'uri'}, $request, $result);
+          }
+       }
+       $HEADERS_STS{ $mark->{hostname} }{ $mark->{port} } = 1;
     }
 
     if (!$HEADERS_XCTO{ $mark->{hostname} }{ $mark->{port} } && defined $result->{'whisker'}->{'code'}) {


### PR DESCRIPTION
From my understanding a ```max-age=0``` value on a HSTS header will disable HSTS.

According to the RFC ```A max-age value of zero (i.e., "max-age=0") signals the UA to cease regarding the host as a Known HSTS Host``` https://tools.ietf.org/html/rfc6797

My Perl is very rusty so you may want to pay close attention to the code I implemented.