### PR TITLE
Add match for InnovaStudio file uploader (ASP)

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6849,3 +6849,4 @@
 "007158","0","e","/g450.html","GET","Avaya G450/G350 - Avaya Device Management","","routerIp","","","Avaya web console found. Default SNMP community string is public","",""
 "007159","0","e","/local-login/","GET","Unified Communications Management","","Avaya","","","Avaya System Manager web console found. Default credential is admin:admin","",""
 "007160","0","3","@WORDPRESSwp-content/plugins/simply-static/debug.txt","GET","class-ss-archive","","","","","Wordpress Simply Static debug log may reveal site information","",""
+"007161","0","0","/Editor/assetmanager/assetmanager.asp","GET","Upload\sFile","","","","","InnovaStudio file uploader found","",""


### PR DESCRIPTION
This PR adds a match for InnovaStudio file uploader in ASP to `db_test`:

`"007161","0","0","/Editor/assetmanager/assetmanager.asp","GET","Upload\sFile","","","","","InnovaStudio file uploader found","",""`

This complements the existing match for the PHP uploader:

`"006957","0","0","/Editor/assetmanager/assetmanager.php","GET","Upload\sFile","","","","","InnovaStudio file uploader found","",""`

Both the PHP and ASP versions be leveraged to gain code execution.

