### PR TITLE
Add a new plugin for detection CORS Origin header reflection

### DIFF
--- a/program/plugins/nikto_origin_reflection.plugin
+++ b/program/plugins/nikto_origin_reflection.plugin
@@ -1,0 +1,49 @@
+#VERSION,2.01
+###############################################################################
+#  Copyright (C) 2017 Chris Sullo
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; version 2
+#  of the License only.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to
+#  Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+###############################################################################
+# PURPOSE:
+# Check for CORS reflection attacks as described in http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
+###############################################################################
+sub nikto_origin_reflection_init {
+    my $id = {
+        name        => "origin_reflection",
+        full_name   => "CORS Origin Reflection",
+        author      => "ss23",
+        description => "Check whether a given Origin header is reflected back in a Access-Control-Allow-Origin header",
+        hooks       => {
+                   scan      => { method => \&nikto_origin_reflection, },
+                   },
+        copyright => "2017 Chris Sullo"
+        };
+    return $id;
+}
+
+sub nikto_origin_reflection {
+    my ($mark, $parameters) = @_;
+    my %headers;
+
+    $headers{'Origin'} = 'nikto.example.com';
+
+    my ($res, $content, $error, $request, $response) = nfetch($mark, $path, "GET", "", \%headers, "", "origin_reflection");
+    if ($response->{'Access-Control-Allow-Origin'} =~ /nikto\.example\.com/) {
+        # TODO: Set the Nikto ID appropriately instead of 999950
+        add_vulnerability($mark, "$path: Site appears vulnerable to the CORS Origin reflection.", 999950, 0, "GET", $path, $request, $response);
+    }
+}
+
+1;


### PR DESCRIPTION
The issue seems to be that some applications or servers will simply reflected a given Origin header back in the Access-Control-Allow-Origin response, leading to a CORS bypass.

The issue is discussed further in: http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html

Unfortunately, by the time I wrote this plugin, the client had patched the site I was testing on, so I no longer have a site to verify the plugin is working as expected. As this is my first plugin, I'd prefer to have a real site to test on, so if anyone has one and can test for me, that would be much apperciated.

I also don't know what to set the "Nikto ID" to in `add_vulnerability`, so any help there would be useful.