### PR TITLE
Remove hard-coded path in man page

### DIFF
--- a/program/docs/nikto.1
+++ b/program/docs/nikto.1
@@ -14,7 +14,7 @@
 nikto \- Scan web server for known vulnerabilities
 .SH "SYNOPSIS"
 .HP 21
-\fB/usr/local/bin/nikto\fR [options...]
+\fBnikto\fR [options...]
 .SH "DESCRIPTION"
 .PP
 Examine a web server to find potential problems and security vulnerabilities, including:


### PR DESCRIPTION
Almost no man pages specify the path to the binary, since it's arbitrary where most programs execute from.