### PR TITLE
GlassFish version numbers are not IP addresses

### DIFF
--- a/program/plugins/nikto_headers.plugin
+++ b/program/plugins/nikto_headers.plugin
@@ -73,6 +73,7 @@ sub nikto_headers_postfetch {
         elsif (defined $HFOUND{$header}) { next; }
 	
 	next if $header eq 'server' && substr($result->{$header}, 0, 8) eq 'WebSEAL/';
+	next if $header eq 'x-powered-by' && $result->{$header} =~ /Oracle GlassFish Server [0-9]/;
 
         foreach my $ip (get_ips($result->{$header})) {
             my ($valid, $internal, $loopback) = is_ip($ip);


### PR DESCRIPTION
In case of GlassFish servers, the `x-powered-by` header contains the version number, which happens to contain four single-digit parts, resulting in the following lines being printed during a scan.

    + Retrieved x-powered-by header: Servlet/3.0 JSP/2.2 (Oracle GlassFish Server 3.1.2.2 Java/Oracle Corporation/1.7)
    + IP address found in the 'x-powered-by' header. The IP is "3.1.2.2".

This patch ignores `x-powered-by` headers that contain a GlassFish server banner when looking for IP addresses.