### PR TITLE
Check for .sql file

### DIFF
--- a/program/plugins/nikto_sitefiles.plugin
+++ b/program/plugins/nikto_sitefiles.plugin
@@ -66,7 +66,7 @@ sub nikto_sitefiles {
 
     foreach my $item (keys %names) {
         next if $item eq '';
-        foreach my $ext (qw/jks cer pem zip tar tar.gz tgz tar.bz2 tar.lzma alz egg war/) {
+        foreach my $ext (qw/jks cer pem zip tar tar.gz tgz tar.bz2 tar.lzma alz egg war sql/) {
             $files{"$item\.$ext"} = 1;
         }
     }


### PR DESCRIPTION
We did some research for this file being exposed, which we will be releasing a blog post about soon. 

> Out of the 852,301 (85%) of sites that we were able to check, we identified that 736 (0.086%) of them were exposing their database export files publicly with the same name as their domain. This may not seem like a lot, but when you consider the impact of the database contents being exposed to malicious actors, it is a considerable risk to the affected individual sites, and their users.