### PR TITLE
Install perl-net-ssleay for SSL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 LABEL Author Paul Sec (https://github.com/PaulSec)
 
-RUN apk add --no-cache git make perl
+RUN apk add --no-cache git make perl perl-net-ssleay
 RUN git clone https://github.com/sullo/nikto
 
 ENV PATH /nikto/program:$PATH


### PR DESCRIPTION
https://github.com/sullo/nikto/pull/551 has shown the following:

> - ***** SSL support not available (see docs for SSL install) *****

Adding perl-net-ssleay like shown in the requirements on https://cirt.net/nikto2-docs/installation.html#id2743216 should bring SSL support into the docker installation.