### PR TITLE
add ignore file detection

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6909,3 +6909,5 @@
 "007221","0","3","/firebase.json","GET","hosting\"(\s+)?\:","","","","","Firebase config file found. It may contain sensitive information.","",""
 "007222","0","d","/ws.asmx","GET","Web\sService","","","","","Webservice found","",""
 "007223","0","d","/ws/ws.asmx","GET","Web\sService","","","","","Webservice found","",""
+"007224","0","23","/.gitignore","GET","200","","","","",".gitignore file found. It is possible to grasp the directory structure.","",""
+"007225","0","23","/.hgignore","GET","200","","","","",".hgignore file found. It is possible to grasp the directory structure.","",""


### PR DESCRIPTION
If .gitignore and .hgignore are published, there is a possibility that you can grasp the directory structure.
In that case, the location of the credential file may be identified and exploited.

Ignorefile often indicates the location of the credential file and I think that detection is necessary.