### PR TITLE
add .env file detection

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6911,3 +6911,4 @@
 "007223","0","d","/ws/ws.asmx","GET","Web\sService","","","","","Webservice found","",""
 "007224","0","23","/.gitignore","GET","200","","","","",".gitignore file found. It is possible to grasp the directory structure.","",""
 "007225","0","23","/.hgignore","GET","200","","","","",".hgignore file found. It is possible to grasp the directory structure.","",""
+"007225","0","23","/.env","GET","200","","","","",".env file found. The .env file may contain credentials.","",""


### PR DESCRIPTION
.env contains several credentials.
.env is used in several web frameworks such as Laravel.
However, there is a possibility that a third party can view it due to misconfiguration of the web server.
(E.g. https://twitter.com/finnwea/status/967709791442341888 )

There is also a vulnerability in older versions of Laravel, and there is the possibility of exploiting .env. CVE-2017-16894

Therefore, I think that detection of .env is necessary.