### PR TITLE
Use COPY instead of clone the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:edge
 
 LABEL Author Paul Sec (https://github.com/PaulSec)
 
-RUN apk add --no-cache git make perl perl-net-ssleay
-RUN git clone https://github.com/sullo/nikto
+RUN apk add --no-cache make perl perl-net-ssleay
+COPY . /nikto
 
 ENV PATH /nikto/program:$PATH
 


### PR DESCRIPTION
The PR removes git from dependencies and copy the project directly inside the image instead of cloning the project again. What do you think @PaulSec?