### PR TITLE
Add tests for openid connect and oauth 2 configuration metadata

### DIFF
--- a/program/databases/db_tests
+++ b/program/databases/db_tests
@@ -6929,3 +6929,5 @@
 "007240","0","7","/WEBACCOUNT.CGI?OkBtn=++Ok++&RESULTPAGE=..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2FWindows%2Fsystem.ini&USEREDIRECT=1&WEBACCOUNTID=&WEBACCOUNTPASSWORD=","GET","wave=","","","","","Argus Surveillance DVR 4.0.0.0 contains a local file retrieval vulnerability","",""
 "007240","0","f","/util/xmlrpc/Handler.ashx","GET","EPiServer.Blog 7.0(\.([0-4]|5([0-7]|8[1-5])))?","","","","","EpiServer Blog 7.0.586 and below may contain an XXE vulnerability in the blog module, which is accessible even if the module is not activated. See https://seclists.org/fulldisclosure/2018/Sep/17","",""
 "007241","0","1","/util/xmlrpc/Handler.ashx","GET","EPiServer XMLRPC","","","","","EpiServer API discovered","",""
+"007242","0","3","/.well-known/openid-configuration","GET","issuer","","","","","OpenID Provider Configuration Information.","",""
+"007243","0","3","/.well-known/oauth-authorization-server","GET","issuer","","","","","OAuth 2.0 Authorization Server Metadata.","",""


### PR DESCRIPTION
OpenID Connect(OIDC) and OAuth 2.0 have [Well-Known URIs](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml) for configuration metadata in json format.

New tests:
- `/.well-known/openid-configuration`
- `/.well-known/oauth-authorization-server`

Documentation:
[OIDC](https://openid.net/specs/openid-connect-discovery-1_0.html#WellKnownContents)
[OAuth 2.0](https://tools.ietf.org/html/rfc8414#section-7.3.1)