### PR TITLE
fix JSON reporting

### DIFF
--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -65,7 +65,7 @@ sub json_host_start {
 # end output
 sub json_host_end {
     my ($handle, $mark) = @_;
-    print $handle "],";
+    print $handle "]";
     return;
 }                                                                
 ###############################################################################


### PR DESCRIPTION
This PR should fix the json reporting output and closes #599 

There are few issues with the current reporting as shown in #599:

1- Extra comma after square brackets which used in `vulnerabilities`
2- Extra comma at the end of the last json item.
3- Extra curly brace in case the host is not available like this:
```
{"id": "000029","url":"/","msg":"No web server found on localhost:8000"},}
```

- For the first point i managed to fix it by removing the extra comma which comes after the square bracket.
- For the second and third points i still trying to figure out how should i fix them, My thoughts are reading the content before appending `}\n` in `json_close` so i can either remove the extra comma or change `}\n` to `\n` in case there is no curly brace at the beginning but i still don't know how to achieve this or any other solution that could help, any guidance on this ?
> note that i don't have prior experience in perl itself but i am trying to figure it out so i can fix the issue.