### PR TITLE
db_variables: Fix @WORDPRESS variable expansion

### DIFF
--- a/program/databases/db_variables
+++ b/program/databases/db_variables
@@ -54,4 +54,4 @@
 @SYMPHONY=/ /cms/ /symphony/
 @CKEDITOR=/ /ckeditor/ /admin/ckeditor/ /sites/all/modules/ckeditor/ /resources/ckeditor/ /clientscript/ckeditor/ /wp-content/plugins/ckeditor-for-wordpress/ckeditor/
 @STRUTSACTIONS=/ /index.action /login.action
-@WORDPRESS=/ /wordpress
+@WORDPRESS=/ /wordpress/


### PR DESCRIPTION
Right now
`@WORDPRESS=/ /wordpress`
will expand, for example,
`@WORDPRESSwp-login.php`
into
`/wp-login.php`
`/wordpresswp-login.php`

access.log evidence:
![access.log](https://user-images.githubusercontent.com/15194721/56138554-cfaa6400-5f9f-11e9-9141-4671def61c1b.png)