### PR TITLE
Fixed Syntax Error in the Nikto JSON Format

### DIFF
--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -76,12 +76,19 @@ sub json_close {
     close($handle);
     return OUT;
 }
+
+my $json_item_count = 0;
 ###############################################################################
 # print an item
 sub json_item {
     my ($handle, $mark, $item) = @_;
     foreach my $uri (split(' ', $item->{'uri'})) {
-        my $line = '{';
+        my $line = '';
+        if ( $json_item_count ne 0 ) {
+            $line .= ",";
+        }
+        $json_item_count++;
+        $line .= "{";
 
         $line .= "\"id\": \"" .$item->{'nikto_id'} ."\",";
         if ($item->{'osvdb'} ne '') { $line .= "\"OSVDB\": \"" .$item->{'osvdb'} ."\","; }
@@ -99,7 +106,7 @@ sub json_item {
 		$msg =~ s/^$root$uri:\s//;
         $msg =~ s/"/\\"/g;
         $line .= "\"msg\":\"$msg\"";
-        $line .= "},";
+        $line .= "}";
         print $handle "$line";
     }
 }


### PR DESCRIPTION
The Nikto JSON Output is currently still a bit broken.

Related to #601 and #599

Currently the all entries in the vulnerabilities array have a `,` after them, even the last one, which makes it incompatible with the JSON standard and most parsers.

This PR should fix this, by prepending the `,` to all entries in the vulnerabilities array, except the last one.