### PR TITLE
Automatically build & push nikto docker image to github package registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build and push nikto image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: docker.pkg.github.com
+          repository: sullo/nikto/nikto
+          tag_with_ref: true
+          tag_with_sha: true


### PR DESCRIPTION
Hi 👋
I've added a small GitHub ci pipeline to automatically build and push the nikto docker image into the GitHub Package Registry using the official docker build action. It currently configured to only run on the master branch and on git tags. It'll create two tags for every commit: `latest` and a tag containing the git sha e.g. `sha-7c13695`

If merged Users would not have to build the image by by hand but could pull it directly from GitHub. The final image name would then be: `docker.pkg.github.com/sullu/nikto/nikto`.