### PR TITLE
Add IPv6 support

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -410,11 +410,11 @@ sub dump_target_info {
     }
 
     if ($CLI{'plugins'} ne '@@NONE') {
-        if ($mark->{ip} =~ /[a-z]/i) {
-            nprint("+ Target IP:          (proxied)", "", $mark);
+        if ($mark->{ip} =~ /^$LW2::IPv4_re$/ || $mark->{ip} =~ /^$LW2::IPv6_re_inc_zoneid$/) {
+            nprint("+ Target IP:          $mark->{ip}", "", $mark);
         }
         else {
-            nprint("+ Target IP:          $mark->{ip}", "", $mark);
+            nprint("+ Target IP:          (proxied)", "", $mark);
         }
 
         nprint("+ Target Hostname:    $mark->{hostname}", "", $mark);
@@ -966,44 +966,61 @@ sub resolve {
         return $ident, $ident, $ident;
     }
 
-    if ($ident =~ /[^0-9\.]/)    # not an IP, assume name & resolve
+    if ($ident =~ /^$LW2::IPv4_re$/) {  # ident is IPv4
+        $ip = $name = $ident;   
+    } elsif ( $ident =~ /^\[($LW2::IPv6_re_inc_zoneid)\]$/ ) {
+        $ip = $1;
+        $name = $ident; # HTTP host header uses [IPv6] rather than the raw IPv6 address
+    }
+    else  # not an IP, assume name & resolve
     {
         if ($CLI{'skiplookup'}) {
             print("+ ERROR: -nolookup set, but given name\n");
             exit;
         }
 
-    if ($hent = gethostbyname($ident)) {
-         # my $name      = $hent->name;  ## Future--report multiple names
-         my $addr_ref  = $hent->addr_list;
-         @addresses = map { inet_ntoa($_) } @$addr_ref;
-    }
-
-    $ip = $addresses[0];
-    if ($addresses[1] != "") {
-	$ipcache = "Multiple IP addresses found: $ip, ";
-	for (my $i=1; $i<=$#addresses; $i++) {
-		$ipcache .= "$addresses[$i], ";
-	}
-        $ipcache =~ s/, $//;
-    }
-
-   if ($ip !~ /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/) {
-       nprint("+ ERROR: Invalid IP: $ip\n\n");
-       exit;
-   }
-       $name = $ident;
-     }
-   else    # ident is IP
-    {
-        if ($ident !~ /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/) {
-            nprint("+ ERROR: Invalid IP: $ident\n\n");
-            return;
+        if ( $LW2::LW2_CAN_IPv6 ) { # IPv4/v6 resolve
+            use Socket qw(:addrinfo SOCK_RAW);
+            
+            my ($err, @res) = Socket::getaddrinfo($ident, "", {socktype => SOCK_RAW});
+            if ($err) {
+                nprint("+ ERROR: Cannot resolve hostname '$ident' because '$err'\n");
+                return;
+            }
+            
+            ## Future--report multiple names
+            foreach my $res (@res) {
+                my ($err, $ip) = Socket::getnameinfo( $res->{addr}, NI_NUMERICHOST, NIx_NOSERV );
+                push @addresses, $ip unless $err;
+            }
+        
+        } else { # Traditional IPv4 resolve
+            if ($hent = gethostbyname($ident)) {
+                 # my $name      = $hent->name;  ## Future--report multiple names
+                 my $addr_ref  = $hent->addr_list;
+                 @addresses = map { inet_ntoa($_) } @$addr_ref;
+            }
         }
 
-        $ip = $name = $ident;
-    }
+        $ip = $addresses[0];
+        if ($addresses[1] != "") { 
+            $ipcache = "Multiple IP addresses found: $ip, ";
+        	for (my $i=1; $i<=$#addresses; $i++) {
+                $ipcache .= "$addresses[$i], ";
+            }
+            $ipcache =~ s/, $//;
+        }
 
+        if ( $ip !~ /^$LW2::IPv4_re$/ &&
+             $ip !~ /^$LW2::IPv6_re$/
+        ) {
+            nprint("+ ERROR: Invalid IP: $ip\n\n");
+            exit;
+        }
+
+        $name = $ident;
+     }
+ 
     my $displayname = ($name) ? $name : $ip;
     return $name, $ip, $displayname, $ipcache;
 }
@@ -1057,7 +1074,7 @@ sub set_targets {
         }
     }
 
-    # Now parse the list of checkhosts, store in %targs by host:port
+    # Now parse the list of checkhosts, store in %targs by host_port
     my $targs = {};
     foreach my $host (@checkhosts) {
         $host =~ s/\s+//g;
@@ -1075,24 +1092,37 @@ sub set_targets {
 
             $defhost = $hostdata[2];
             $defport = $hostdata[3];
-            $targs{ $defhost . ":" . $defport } = ($root ne "") ? $root : '/';
+            $targs{ $defhost . "_" . $defport } = ($root ne "") ? $root : '/';
 
             if (($hostdata[0] ne '/') && ($hostdata[0] ne '') && ($root eq '')) {
                 $hostdata[0] =~ s/\/$//;
-                $targs{ $defhost . ":" . $defport } = $hostdata[0];
+                $targs{ $defhost . "_" . $defport } = $hostdata[0];
                 nprint("- Added -root value of '$hostdata[0]' from URI", "v");
             }
         }
         else {
-            my @h = split(/\:|\,/, $host);
-            $defhost = $h[0];
-            $defport = $h[1];
-            $targs{ $defhost . ":" . $defport } = ($root ne "") ? $root : '/';
+            if ( (index $host, '[') == 0) { # looks like accepted IPv6 format
+                if ($host =~ /^(\[$LW2::IPv6_re_inc_zoneid\])(?:[:](\d+))?$/) {
+                    $defhost = $1;
+                    $defport = $2;                
+                } else {
+                    nprint("- ERROR: Unrecognised target host format: $host");
+                }
+            } else {
+                my @h = split(/\:|\,/, $host); # Q. Is host,port format ever going to reach here, or will the port be incorrectly split off earlier as another host
+                $defhost = $h[0];
+                $defport = $h[1];
+                if (scalar @h > 2) { # Possible invalid IPv6 format has been supplied
+                  nprint("- ERROR: Target host '$host' contains more than one colon (:). If specifying an IPv6 target, use the [IPv6] format.");
+                  # TODO skip this host if going through a file of targets
+                }
+            }
+            $targs{ $defhost . "_" . $defport } = ($root ne "") ? $root : '/';
         }
     }
 
     foreach my $host (keys %targs) {
-        my ($h, $p) = split(/:/, $host);
+        my ($h, $p) = split(/_/, $host);
         if ($p eq '') {
             foreach my $port (@ports) {
                 my $markhash = {};
@@ -2434,7 +2464,7 @@ sub max_test_id {
 sub get_ips {
     my $string = $_[0] || return;
     my @ips;
-    while ($string =~ /(?:\b|[^0-9v])([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})(?:\b|[^0-9])/g) {
+    while ($string =~ /(?:\b|[^0-9v])($LW2::IPv4_re|$LW2::IPv6_re_inc_zoneid)(?:\b|[^0-9])/g) {
         push(@ips, $1);
     }
     return @ips;
@@ -2447,26 +2477,39 @@ sub is_ip {
     my $internal = 0;
     my $loopback = 0;
 
-    # simple syntax check
-    # this will fail on some edge cases, but it's 99%...
-    if ($ip !~ /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/) {
+    if ($ip =~ /^$LW2::IPv4_re$/) {
+
+        # now validate octets - may not be necessary now with use of $LW2::IPv4_re ?
+        my @octets = split(/\./, $ip);
+        if (scalar(@octets) ne 4) { return 0, $internal, $loopback; }
+        for (my $o = 0 ; $o <= 3 ; $o++) {
+            if (($octets[$o] < 0) || ($octets[$o] > 255)) { return 0, $internal, $loopback; }
+            if ($octet[$o] =~ /^0/) { return 0, $internal, $loopback; }
+            if (($o eq 0) && ($octets[$o] < 1)) { return 0, $internal, $loopback; }
+        }
+
+        # now check for internal
+        if ($ip =~ /^(?:10|192\.168|172\.(?:1[6-9]|2\d|3[01]))\./) { $internal = 1; }
+
+        # lastly, loopback?
+        if ($ip eq '127.0.0.1') { $loopback = 1; }
+
+    } elsif ($ip =~ /^$LW2::IPv6_re_inc_zoneid(?:\/[0-9]+)?$/) {
+
+        # now check for internal
+
+        if ( $ip =~ /^(?:fe80     # is a link local unicast address
+                                          |ff0[1-8] # is a multicast address
+                                          |fc00     # private network
+        ):/ix ) { $internal = 1 ;}
+
+        # lastly, loopback?
+        # This is a bit rough 'n' ready, could do with some finesse
+        if ($ip =~ /^[01:]+(?:\/[0-9]+)?$/) { $loopback = 1; }
+
+    } else {
         return 0, $internal, $loopback;
     }
-
-    # now validate octets
-    my @octets = split(/\./, $ip);
-    if (scalar(@octets) ne 4) { return 0, $internal, $loopback; }
-    for (my $o = 0 ; $o <= 3 ; $o++) {
-        if (($octets[$o] < 0) || ($octets[$o] > 255)) { return 0, $internal, $loopback; }
-        if ($octet[$o] =~ /^0/) { return 0, $internal, $loopback; }
-        if (($o eq 0) && ($octets[$o] < 1)) { return 0, $internal, $loopback; }
-    }
-
-    # now check for internal
-    if ($ip =~ /^(?:10|192\.168|172\.(?:1[6-9]|2\d|3[01]))\./) { $internal = 1; }
-
-    # lastly, loopback?
-    if ($ip eq '127.0.0.1') { $loopback = 1; }
 
     return 1, $internal, $loopback;
 }

--- a/program/plugins/nikto_fileops.plugin
+++ b/program/plugins/nikto_fileops.plugin
@@ -205,7 +205,7 @@ sub parse_hostfile {
             my @fields = split("\t", $_);
 
             # Get the host name
-            $fields[0] =~ /Host:\s+([\d\.]+)\s+\(([^\)]+)?\)/;
+            $fields[0] =~ /Host:\s+($LW2::IPv4_re|$LW2::IPv6_re_inc_zoneid)\s+\(([^\)]+)?\)/;
             $hostdesc = ($2 ne "") ? $2 : $1;
 
             # Parse the ports list from:
@@ -219,7 +219,7 @@ sub parse_hostfile {
                 }
                 $nmp =~ /^(?:\s+)?(\d+)\//;
                 nprint("+ nmap Input Queued: $hostdesc:$1");
-                push(@results, $hostdesc . ":" . $1);
+                push(@results, $hostdesc . "_" . $1);
             }
         }
         else {


### PR DESCRIPTION
Main changes:

In LW2.pm:
* New **$IPv4_re**, **$IPv6_re**, **$IPv6_re_inc_zoneid** compiled regular expressions; can be used in other plugins with the $LW2:: prefix (e.g. $LW2::IPv4_re)
* New $LW2_CAN_IPv6 variable reflecting whether the version of Socket.pm supports IPv6. It does not reflect whether the host OS and connectivity to the target support IPv6! Can also be used elsewhere with $LW2:: prefix.
* When Socket.pm supports IPv6, both IPv4 and IPv6 name resolutions use getaddrinfo(). Otherwise the longstanding socket code is used.

In nikto_core.plugin:
* Target format in %targs changed from host:port to host_port, since colons are used in IPv6 addresses
* get_ips and is_ip modified to support IPv6; not sure if/when zone ids or prefixes will be relevant here, so some finessing may be required down the line.
* The $LW2::IPv4_re regex is more accurate than the "simple syntax check" previously in is_ip(). The octet validation block may well no longer be needed, but I left it unchanged for now.
* Various other modifications to support IPv6 addresses

In nikto_fileops.plugin:
* Couple of modifications to support IPv6 addresses