### PR TITLE
Add issue templates for bugs and false positive / negative reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Report an issue found in Nikto
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce
+
+1.
+2.
+3.
+
+### Nikto version
+
+Run:
+
+```
+./nikto.pl -Version
+```
+
+and paste the output here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Nikto Mail List
+    url: https://attrition.org/mailman/listinfo/nikto-discuss
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Nikto Mail List
-    url: https://attrition.org/mailman/listinfo/nikto-discuss
-    about: Please ask and answer questions here.
+  - name: Nikto Announce List
+    url: https://mailchi.mp/b71a3a0491a6/nikto-announce
+    about: Infrequent Nikto announcements

--- a/.github/ISSUE_TEMPLATE/false_positive_negative_report.md
+++ b/.github/ISSUE_TEMPLATE/false_positive_negative_report.md
@@ -1,0 +1,23 @@
+---
+name: False positive / negative Report
+about: Report a false positive / negative found by Nikto
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Output of suspected false positive / negative
+
+Post any useful information like the ID of the test causing the false positive.
+
+### Debug output
+
+Run:
+
+```
+./nikto.pl -host targethost -Save false_positive
+```
+
+This saves all positive responses to a new `false_positive` directory. Afterwards look
+for the related ID of the false positive / negative and paste it below.


### PR DESCRIPTION
Info about this can be found here:

https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository

Could help to get the info for issues like https://github.com/sullo/nikto/issues/652 directly without having to ask for more info later.