### PR TITLE
Make clear that scan was terminated

### DIFF
--- a/program/nikto.pl
+++ b/program/nikto.pl
@@ -204,7 +204,7 @@ foreach my $mark (@MARKS) {
         }
         else {
             nprint(
-                "+ Scan terminated:  $mark->{'total_errors'} error(s) and $mark->{'total_vulns'} item(s) reported on remote host"
+                "+ SCAN TERMINATED:  $mark->{'total_errors'} error(s) and $mark->{'total_vulns'} item(s) reported on remote host"
                 );
         }
         nprint(  "+ End Time:           "


### PR DESCRIPTION
HI,

I realize that there's a line with the word "ERROR" before but to make better clear that there was a scanning problem I suggest to emphasize that in caps:

```
+ ERROR: Error limit (20) reached for host, giving up. Last error: opening stream: can't connect (timeout): Interrupted system call
+ SCAN TERMINATED:  20 error(s) and 4 item(s) reported on remote host
+ End Time:           2020-09-14 14:45:35 (GMT2) (406 seconds)
---------------------------------------------------------------------------
```

This was from a scan where I mimicked a server-side blocking I encountered in real life, like with fail2ban which occurred in the middle of a scan.

Cheers, Dirk