### PR TITLE
Fix outdated OpenSSL string.

### DIFF
--- a/program/databases/db_outdated
+++ b/program/databases/db_outdated
@@ -605,7 +605,7 @@
 "600592","Open-Market-SecureLink-Bridge/","V2.1.RC0","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600593","OpenPKG/","2.5","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600594","OpenSA/","1.0.4","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
-"600595","OpenSSL/","1.1.1gi,"@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER). OpenSSL 1.0.0o and 0.9.8zc are also current."
+"600595","OpenSSL/","1.1.1i,"@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER). OpenSSL 1.0.0o and 0.9.8zc are also current."
 "600596","oplweb/","1.0","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600597","Oracle HTTP Server Powered by Apache/","1.3.22","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"
 "600598","Oracle_Web_Listener_NT_","2.1.0.3.1/1.20in2","@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)"


### PR DESCRIPTION
Fix for the change from 55ab4a71816b95945954578411cae77f45ae1f9c, there is no version `gi` but just `i`.