### PR TITLE
GH#489 - plumb in the -ipv4/-ipv6/-check6 flags

### DIFF
--- a/program/plugins/LW2.pm
+++ b/program/plugins/LW2.pm
@@ -5046,6 +5046,8 @@ sub _stream_socket_alloc {
     if ($LW2_CAN_IPv6) {
         
         my ($ip, $port);
+
+        $xr->{sock_hints}->{family} = ( $main::CLI{'ipv6'} ) ?  AF_INET6 :  AF_INET ;
         
         if ( defined $wh->{whisker}->{bind_socket} ) {
             $port = $wh->{whisker}->{bind_port} || 0;
@@ -5065,7 +5067,7 @@ sub _stream_socket_alloc {
             ($ip,$port) = ($xr->{chost}, $xr->{cport});
         }
         
-        my ($err, @results) = getaddrinfo($ip, $port, $xr->{sock_hints} );
+        my ($err, @results) = getaddrinfo($ip, $port, $xr->{sock_hints});
         return _stream_err( $xr, 0, "getaddrinfo problems ($err)" ) if $err;
         return _stream_err( $xr, 0, 'getaddrinfo problems (no sockets)' )
           if ( scalar(@results) < 1);
@@ -6041,7 +6043,8 @@ sub utils_port_open {    # this should be platform-safe
 
         my ($err, @results) =
             getaddrinfo($target, $port, {
-                socktype => SOCK_STREAM, protocol => IPPROTO_TCP
+                socktype => SOCK_STREAM, protocol => IPPROTO_TCP,
+                family => ( $main::CLI{'ipv6'} ) ?  AF_INET6 :  AF_INET
                 } );
 
         foreach my $sk (@results) {

--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1119,7 +1119,9 @@ sub resolve {
         if ( $LW2::LW2_CAN_IPv6 ) { # IPv4/v6 resolve
             use Socket qw(:addrinfo SOCK_RAW);
 
-            my ($err, @res) = Socket::getaddrinfo($ident, "", {socktype => SOCK_RAW});
+            my ($err, @res) = Socket::getaddrinfo($ident, "", {socktype => SOCK_RAW, 
+                                  family => ( $CLI{'ipv6'} ) ?  AF_INET6 :  AF_INET
+                                  });
             if ($err) {
                 nprint("+ ERROR: Cannot resolve hostname '$ident' because '$err'\n");
                 return;
@@ -3164,7 +3166,42 @@ sub expand_range {
 }
 ###############################################################################
 sub check_ipv6 {
-    # Do something and: exit 1 or 0 
+    nprint("Performing IPv6 connectivity tests:");
+    # Perform a series of tests and: exit 1 or 0
+
+    # Does the version of Socket even support IPv6?
+    if (! $LW2::LW2_CAN_IPv6 ) {
+        nprint("+ ERROR: This version of Socket ($Socket::VERSION) has insufficient (or no) IPv6 support");
+        exit 1;
+    }
+    nprint("+ This version of Socket ($Socket::VERSION) does support IPv6");
+
+    # Ensure switches are in a known state
+    $CLI{'ipv6'} = 1; $CLI{'ipv4'} = 0;
+
+    # Test host & port could be extracted out into the config file
+    my $check6host = 'ipv6.google.com';
+    my $check6port = 443;
+
+    # Try to resolve a known IPv6 hostname
+    my ($name, $ip, $displayname, $ipcache) = resolve($check6host);
+    if (! $ip) {
+        nprint("- DNS resolution of '$check6host' using AF_INET6 failed");
+        nprint("\t(Perhaps no DNS server set or server is incapable of resolving an IPv6 address for the test host)");
+        exit 1;
+    }
+    nprint("+ Successful DNS resolution of '$check6host': $ip");
+
+    # Try to connect to the host
+    my $res = LW2::utils_port_open($check6host, $check6port);
+    if (! $res) {
+        nprint("+ ERROR: TCP connection to '$check6host:$check6port' using AF_INET6 failed");
+        nprint("\t(Likely either no IPv6 connectivity or firewall blocking)");
+        exit 1;
+    }
+    nprint("+ Successful TCP connection to '$check6host:$check6port'");
+    nprint("----> All tests successful");
+    exit 0;
 }
 ###############################################################################
 sub nikto_core { return; }    # trap for this plugin being called to run. lame.


### PR DESCRIPTION
For https://github.com/sullo/nikto/issues/489: adds in behaviour for the following flags:
* `-ipv4`
* `-ipv6`
* `-check6`

PS The `-check6` target host (_ipv6.google.com_) is hardcoded, but perhaps it could be useful to make that user-configurable? e.g. for someone who is onsite and wants to test DNS & connectivity for an internal IPv6 target.
