### PR TITLE
Bugfix: Invalid JSON is no longer produced when no web server is found.

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1741,8 +1741,10 @@ sub port_check {
             }
         }
     }
-
+    
+    report_host_start($m)
     add_vulnerability($m,"No web server found on " . ($hostname || $ip) . ":$port", '000029', '0', '', '/', $request, $response, "No HTTP response");
+    report_host_end($m)
     nprint("---------------------------------------------------------------------------");
 
     return 0;

--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1741,10 +1741,10 @@ sub port_check {
             }
         }
     }
-    
-    report_host_start($m)
+
+    report_host_start($m);
     add_vulnerability($m,"No web server found on " . ($hostname || $ip) . ":$port", '000029', '0', '', '/', $request, $response, "No HTTP response");
-    report_host_end($m)
+    report_host_end($m);
     nprint("---------------------------------------------------------------------------");
 
     return 0;


### PR DESCRIPTION
Closes sullo/nikto#740

It fixes the JSON when no web server is found:

`./nikto.pl -h www.example.com -p 8080 -Tuning 1,2,3,5,7,b -o out.json` 

```json
{
   "host":"www.example.com",
   "ip":"93.184.216.34",
   "port":"8080",
   "banner":"",
   "vulnerabilities":[
      {
         "id":"000029",
         "OSVDB":"0",
         "url":"/",
         "msg":"No web server found on www.example.com:8080"
      }
   ]
}
```

The output produced for scans where a web server is found look good to me also.
Both are valid json according to https://jsonformatter.curiousconcept.com/

`./nikto.pl -h http://www.example.com -Tuning 1,2,3,5,7,b -o out.json` 

```json
{
   "host":"www.example.com",
   "ip":"93.184.216.34",
   "port":"80",
   "banner":"ECS (dcb/7F83)",
   "vulnerabilities":[
      {
         "id":"999962",
         "OSVDB":"0",
         "method":"GET",
         "url":"/",
         "msg":"Server banner changed from 'ECS (dcb/7F83)' to 'ECS (dcb/7FA3)'"
      },
      {
         "id":"999957",
         "OSVDB":"0",
         "method":"GET",
         "url":"/",
         "msg":"The anti-clickjacking X-Frame-Options header is not present."
      },
      {
         "id":"999100",
         "OSVDB":"0",
         "method":"GET",
         "url":"/",
         "msg":"Uncommon header 'x-cache' found, with contents: HIT"
      },
      {
         "id":"999103",
         "OSVDB":"0",
         "method":"GET",
         "url":"/",
         "msg":"The X-Content-Type-Options header is not set. This could allow the user agent to render the content of the site in a different fashion to the MIME type."
      },
      {
         "id":"999990",
         "OSVDB":"0",
         "method":"OPTIONS",
         "url":"/",
         "msg":"Allowed HTTP Methods: OPTIONS, GET, HEAD, POST "
      }
   ]
}
```
