### PR TITLE
Fix header checks in shellshock plugin

### DIFF
--- a/program/plugins/nikto_shellshock.plugin
+++ b/program/plugins/nikto_shellshock.plugin
@@ -62,7 +62,7 @@ sub nikto_shellshock {
             add_vulnerability( $mark, "$parameters->{'uri'}: Site appears vulnerable to the 'shellshock' vulnerability).", 999949, "CVE-2014-6271", "GET",
                 "$parameters->{'uri'}", $request, $response);
         }
-        if (($response->{'93e4r0-CVE-2014-6271'} eq 'true') || ($checkcontent && ($content =~ /93e4r0-CVE-2014-6278: true/))) {
+        if (($response->{'93e4r0-CVE-2014-6278'} eq 'true') || ($checkcontent && ($content =~ /93e4r0-CVE-2014-6278: true/))) {
             add_vulnerability( $mark, "$parameters->{'uri'}: Site appears vulnerable to the 'shellshock' vulnerability.", 999948, "CVE-2014-6278", "GET",
                 "$parameters->{'uri'}", $request, $response);
         }
@@ -78,7 +78,7 @@ sub nikto_shellshock {
                     add_vulnerability( $mark, "$cgidir$file: Site appears vulnerable to the 'shellshock' vulnerability.", 999947, "CVE-2014-6271", "GET",
                         "$cgidir$file", $request, $response);
                 }
-                if (($response->{'93e4r0-CVE-2014-6271'} eq 'true') || ($checkcontent && ($content =~ /93e4r0-CVE-2014-6278: true/))) {
+                if (($response->{'93e4r0-CVE-2014-6278'} eq 'true') || ($checkcontent && ($content =~ /93e4r0-CVE-2014-6278: true/))) {
                     add_vulnerability( $mark, "$cgidir$file: Site appears vulnerable to the 'shellshock' vulnerability.", 999946, "CVE-2014-6278", "GET",
                         "$cgidir$file", $request, $response);
                 }


### PR DESCRIPTION
Additional fix required for #749 / 2420e649cd63ab8a1dcfa015c9fa27b7f1f27524 so that the correct CVE is getting flagged.