### PR TITLE
nikto reports shoud overwrite old file; not append

### DIFF
--- a/program/plugins/nikto_report_csv.plugin
+++ b/program/plugins/nikto_report_csv.plugin
@@ -40,7 +40,7 @@ sub csv_open {
     print STDERR "+ ERROR: Output file not specified.\n" if $file eq '';
 
     # Open file and produce header
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     # Write header
     print OUT "\"$VARIABLES{'name'} - v$VARIABLES{'version'}/$VARIABLES{'core_version'}\"\n";

--- a/program/plugins/nikto_report_html.plugin
+++ b/program/plugins/nikto_report_html.plugin
@@ -44,7 +44,7 @@ sub html_head {
     print STDERR "+ ERROR: Output file not specified.\n" if $file eq '';
 
     # Write header for html file, return file handle
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     my $html = html_change_vars($TEMPLATES{'htm_start'});
     $html =~ s/\#NIKTODTD#/$CONFIGFILE{'NIKTODTD'}/;

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -41,7 +41,7 @@ sub json_open {
     my ($file) = @_;
 
     # Open file and produce header
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     # Write header
 #    print OUT "\"$VARIABLES{'name'} - v$VARIABLES{'version'}/$VARIABLES{'core_version'}\"\n";

--- a/program/plugins/nikto_report_nbe.plugin
+++ b/program/plugins/nikto_report_nbe.plugin
@@ -37,7 +37,7 @@ sub nbe_open {
     print STDERR "+ ERROR: Output file not specified.\n" if $file eq '';
 
     # Open file and produce header
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     # Write header
     print OUT

--- a/program/plugins/nikto_report_sqlg.plugin
+++ b/program/plugins/nikto_report_sqlg.plugin
@@ -44,7 +44,7 @@ sub sqlg_open {
     print STDERR "+ ERROR: Output file not specified.\n" if $file eq '';
 
     # Open file and produce header
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     # Write header
     my $opt = $CLI{'all_options'};

--- a/program/plugins/nikto_report_text.plugin
+++ b/program/plugins/nikto_report_text.plugin
@@ -38,7 +38,7 @@ sub text_open {
     print STDERR "+ ERROR: Output file not specified.\n" if $file eq '';
 
     # Open file and produce header
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     # Write header
     print OUT "- $VARIABLES{'name'} v$VARIABLES{'version'}/$VARIABLES{'core_version'}\n";

--- a/program/plugins/nikto_report_xml.plugin
+++ b/program/plugins/nikto_report_xml.plugin
@@ -57,7 +57,7 @@ sub xml_head {
         close(IN);
     }
 
-    open(OUT, ">>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    open(OUT, ">$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
 
     # If file doesn't contain a header, write it
     if (!$header_present) {


### PR DESCRIPTION
While building out a tool to automate nikto scans, I discovered the hard way that nikto was appending reports to the existing one. Running the report multiple times means that the output file is different. I believe that a functional approach is more appropriate, the scan should produce the same output file given the certain arguments.

 This is the first tool of this type that I've seen with this behavior. It seems more intuitive to me that the report should overwrite the existing one.