### PR TITLE
Fix json file format when error occurred

### DIFF
--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -65,14 +65,14 @@ sub json_host_start {
 # end output
 sub json_host_end {
     my ($handle, $mark) = @_;
-    print $handle "]";
+    print $handle "]}";
     return;
 }
 ###############################################################################
 # close output file
 sub json_close {
     my ($handle, $mark) = @_;
-    print $handle "}\n";
+    print $handle "\n";
     close($handle);
     return OUT;
 }


### PR DESCRIPTION
Remove unnecessary closed bracket like below.

```
# 192.168.0.111 doesn't exist.
$ ./nikto.pl -h 192.168.0.111 -o output.json
- Nikto v2.1.6
---------------------------------------------------------------------------
+ No web server found on 192.168.0.111:80
---------------------------------------------------------------------------
+ 0 host(s) tested

$ cat output.json
{"id": "000029","OSVDB": "0","url":"/","msg":"No web server found on 192.168.0.111:80"}}
```