### PR TITLE
Escape message in JSON output

### DIFF
--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -32,6 +32,7 @@ sub nikto_report_json_init {
                report_format     => 'json',
                copyright         => "2016 Chris Sullo"
                };
+    use JSON;
     return $id;
 }
 
@@ -105,7 +106,8 @@ sub json_item {
 		$msg =~ s/^$uri:\s//;
 		$msg =~ s/^$root$uri:\s//;
         $msg =~ s/"/\\"/g;
-        $line .= "\"msg\":\"$msg\"";
+        $msg = JSON->new->encode($msg);
+        $line .= "\"msg\":$msg";
         $line .= "}";
         print $handle "$line";
     }


### PR DESCRIPTION
There are some messages which are not escaped like [here (backslash)](https://github.com/sullo/nikto/blob/master/program/databases/db_tests#L217) in the databases, and an output is sometimes invalid JSON format.

This PR escapes those messages in JSON report plugin.