### PR TITLE
Print errors to STDERR, don't exit 0 on error

### DIFF
--- a/program/nikto.pl
+++ b/program/nikto.pl
@@ -281,7 +281,7 @@ sub load_modules {
     foreach my $mod (@modules) {
         eval "use $mod";
         if ($@) {
-            print "ERROR: Required module not found: $mod\n";
+            print STDERR "ERROR: Required module not found: $mod\n";
             $errors = 1;
         }
     }
@@ -294,7 +294,7 @@ sub load_modules {
         if ($@ && $^O !~ /MSWin32/) {
 
             # Allow this to work on Windows
-            if ($@) { print "ERROR: Required module not found: $mod\n"; $errors = 1; }
+            if ($@) { print STDERR "ERROR: Required module not found: $mod\n"; $errors = 1; }
         }
     }
 
@@ -354,7 +354,7 @@ sub setup_dirs {
         }
         else {
             print STDERR "Could not work out the nikto EXECDIR, try setting it in nikto.conf\n";
-            exit;
+            exit 1;
         }
     }
     unless (defined $CONFIGFILE{'PLUGINDIR'}) {

--- a/program/plugins/LW2.pm
+++ b/program/plugins/LW2.pm
@@ -109,7 +109,7 @@ sub init_ssl_engine {
         	Net::SSLeay::SSLeay_add_ssl_algorithms();
         	Net::SSLeay::randomize();
 		}
-	else  { print "ERROR: $@\n"; exit; }
+	else  { print STDERR "ERROR: $@\n"; exit 1; }
     } elsif ($lw_ssl_engine eq 'SSL'){
         # use Net:SSL
         eval "use Net::SSL";
@@ -117,7 +117,7 @@ sub init_ssl_engine {
         	$LW_SSL_LIB   = 2;
         	$_SSL_LIBRARY = 'Net::SSL';
 		}
-	else  { print "ERROR: $@\n"; exit; }
+	else  { print STDERR "ERROR: $@\n"; exit 1; }
     } 
 	else {
 	# assuming autodetection


### PR DESCRIPTION
- Fixed 4 instances of error messages printing to STDOUT.
- Fixed 3 instance of error conditions exiting 0.