### PR TITLE
Fix nikto json plugin

### DIFF
--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -99,7 +99,7 @@ sub json_item {
     $msg =~ s/^$uri:\s//;
     $msg =~ s/^$root$uri:\s//;
     $msg =~ s/"/\\"/g;
-    $msg = JSON->new->encode($msg);
+    $msg = JSON::PP->new->encode($msg);
     $line .= "\"msg\":\"$msg\"";
     $line .= "},";
     print $handle $line;


### PR DESCRIPTION
WIth recent update when json output was selected nikto couldn't run giving error: `Can't locate object method "new" via package "JSON" at /opt/nikto/program/plugins/nikto_report_json.plugin line 102.`