### PR TITLE
fix invalid/inaccurate json report

### DIFF
--- a/program/nikto.pl
+++ b/program/nikto.pl
@@ -153,8 +153,13 @@ foreach my $mark (@MARKS) {
 # Now we've done the precursor, do the scan
 foreach my $mark (@MARKS) {
     my %FoF = ();
+    report_host_start($mark);
 
     if (!$mark->{'test'}) {
+        if ($mark->{'errmsg'} ne "") {
+            add_vulnerability($mark, $mark->{'errmsg'}, 0, "", "GET", "/", "", "");
+        }
+
         report_host_end($mark);
         next;
     }
@@ -175,11 +180,6 @@ foreach my $mark (@MARKS) {
 
     nfetch($mark, "/", "GET", "", "", { noprefetch => 1, nopostfetch => 1 }, "getinfo");
 
-    report_host_start($mark);
-
-    if ($mark->{'errmsg'} ne "") {
-        add_vulnerability($mark, $mark->{'errmsg'}, 0, "", "GET", "/", "", "");
-    }
 
     dump_target_info($mark);
     unless ((defined $CLI{'nofof'}) || ($CLI{'plugins'} eq '@@NONE')) { map_codes($mark) }

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -42,7 +42,7 @@ sub json_open {
 
     # Open file and produce header
     open(OUT, "+>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
-    print OUT "{";
+    print OUT "[";
 
     return OUT;
 }
@@ -54,7 +54,10 @@ sub json_host_start {
     my ($handle, $mark) = @_;
     $mark->{'banner'} =~ s/"/\\"/g;
     my $hostname = $mark->{'vhost'} ? $mark->{'vhost'} : $mark->{'hostname'};
-    print $handle "\"host\":\"$hostname\","
+
+    if ($json_host_started eq true) { print $handle ","; }
+
+    print $handle "{\"host\":\"$hostname\","
       . "\"ip\":\"$mark->{'ip'}\","
       . "\"port\":\"$mark->{'port'}\","
       . "\"banner\":\"$mark->{'banner'}\","
@@ -69,7 +72,8 @@ sub json_host_start {
 sub json_host_end {
     my ($handle, $mark, $file) = @_;
 
-    if ($json_host_started eq true) { print OUT "]"; }
+    if ($json_host_started eq true) { print OUT "]}"; }
+    $json_item_count = 0;
     return;
 }
 
@@ -77,7 +81,7 @@ sub json_host_end {
 # close output file
 sub json_close {
     my ($handle, $mark) = @_;
-    print $handle "}\n";
+    print $handle "]";
     close($handle);
     return;
 }

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -42,21 +42,25 @@ sub json_open {
 
     # Open file and produce header
     open(OUT, "+>$file") || die print STDERR "+ ERROR: Unable to open '$file' for write: $@\n";
+    print OUT "{";
 
     return OUT;
 }
 
 ###############################################################################
 # start output
+$json_host_started = false;
 sub json_host_start {
     my ($handle, $mark) = @_;
     $mark->{'banner'} =~ s/"/\\"/g;
     my $hostname = $mark->{'vhost'} ? $mark->{'vhost'} : $mark->{'hostname'};
-    print $handle "{\"host\":\"$hostname\","
+    print $handle "\"host\":\"$hostname\","
       . "\"ip\":\"$mark->{'ip'}\","
       . "\"port\":\"$mark->{'port'}\","
       . "\"banner\":\"$mark->{'banner'}\","
       . "\"vulnerabilities\":[";
+
+    $json_host_started = true;
     return;
 }
 
@@ -65,7 +69,7 @@ sub json_host_start {
 sub json_host_end {
     my ($handle, $mark, $file) = @_;
 
-    print OUT "]";
+    if ($json_host_started eq true) { print OUT "]"; }
     return;
 }
 

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -84,6 +84,7 @@ sub json_close {
 # print an item
 sub json_item {
     my ($handle, $mark, $item) = @_;
+    $uri = $item->{'uri'};
     my $line = "{";
     $line .= "\"id\": \"" . $item->{'nikto_id'} . "\",";
     if ($item->{'refs'} ne '')   { $line .= "\"references\": \"" . $item->{'refs'} . "\","; }

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -100,7 +100,7 @@ sub json_item {
     $msg =~ s/^$root$uri:\s//;
     $msg =~ s/"/\\"/g;
     $msg = JSON::PP->new->encode($msg);
-    $line .= "\"msg\":\"$msg\"";
+    $line .= "\"msg\":$msg";
     $line .= "},";
     print $handle $line;
 }

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -99,7 +99,7 @@ sub json_item {
     $msg =~ s/^$uri:\s//;
     $msg =~ s/^$root$uri:\s//;
     $msg =~ s/"/\\"/g;
-    $msg = JSON->new->encode($msg);
+    $msg = JSON::PP->new->encode($msg);
     $line .= "\"msg\":\"$msg\"";
     $line .= "},";
     print $handle $line;

--- a/program/plugins/nikto_report_json.plugin
+++ b/program/plugins/nikto_report_json.plugin
@@ -65,8 +65,6 @@ sub json_host_start {
 sub json_host_end {
     my ($handle, $mark, $file) = @_;
 
-    # this is remove the last , that json_item() left, and overwrite with ] to close the host
-    seek($handle, -1, 2);
     print OUT "]";
     return;
 }
@@ -82,10 +80,17 @@ sub json_close {
 
 ###############################################################################
 # print an item
+$json_item_count = 0;
 sub json_item {
     my ($handle, $mark, $item) = @_;
+    $json_item_count++;
+
     $uri = $item->{'uri'};
-    my $line = "{";
+    my $line = "";
+
+    if ($json_item_count gt 1) { $line .= ","; }
+
+    $line .= "{";
     $line .= "\"id\": \"" . $item->{'nikto_id'} . "\",";
     if ($item->{'refs'} ne '')   { $line .= "\"references\": \"" . $item->{'refs'} . "\","; }
     if ($item->{'method'} ne '') { $line .= "\"method\":\"" . $item->{'method'} . "\","; }
@@ -102,7 +107,7 @@ sub json_item {
     $msg =~ s/"/\\"/g;
     $msg = JSON::PP->new->encode($msg);
     $line .= "\"msg\":$msg";
-    $line .= "},";
+    $line .= "}";
     print $handle $line;
 }
 


### PR DESCRIPTION
# Base
- applied AER00 patch https://github.com/sullo/nikto/pull/807

# Problems
- `encode` function from `JSON:PP` adds own quotes to encoded text. Because of that `"msg"` field was encoded incorrectly (`"msg": ""[some info]""`)
- $uri was never set which resulted in empty value in the report
- in `json_item` commas was blindly added after every item and then removed in `json_host_end` using `seek(...)`. If there were no vulnerabilities found, instead of comma, '[' would be removed.
- if the specified target does not exist, `json_host_start` is not executed, despite that `json_host_end` is. Because of that report ends up with invalid json `]}`
- for some reason `report_host_end` was called before `report_host_start`, thus resulting in weird behavior of json report plugin
- json report was not usable with multiple hosts specified