### PR TITLE
fix: add space in err msgs for proper autodetecion

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -841,12 +841,12 @@ sub general_config {
     }
 
     if ((defined $CLI{'file'}) && ($CLI{'format'} eq "")) {
-        nprint("+ERROR: Output file specified without a format");
+        nprint("+ ERROR: Output file specified without a format");
         exit 1;
     }
 
     if ((!defined $CLI{'file'}) && ($CLI{'format'} ne "none")) {
-        nprint("+ERROR: Output file format specified without a name");
+        nprint("+ ERROR: Output file format specified without a name");
         exit 1;
     }
 
@@ -1761,7 +1761,7 @@ sub check_dbs {
     foreach my $id (keys %ALL_IDS) {
         chomp($id);
         next if (($id eq 0) || ($id eq '') || ($id eq 'nikto_id'));
-        if ($id =~ /[^\d]/)  { nprint("+ERROR: Invalid test ID: $id"); next; }
+        if ($id =~ /[^\d]/)  { nprint("+ ERROR: Invalid test ID: $id"); next; }
         if (length($id) < 6) { nprint("+WARNING: Possibly invalid test ID: $id"); }
     }
 

--- a/program/plugins/nikto_fileops.plugin
+++ b/program/plugins/nikto_fileops.plugin
@@ -136,7 +136,7 @@ sub save_createdir {
         $savedir .= "_" . $now;
     }
     elsif (-f $savedir) {
-        nprint("+ERROR: Directory from -Savedir is a file.");
+        nprint("+ ERROR: Directory from -Savedir is a file.");
         exit;
     }
 
@@ -144,7 +144,7 @@ sub save_createdir {
     if (!-d $savedir) {
         mkdir($savedir);
         if (!-d $savedir) {
-            nprint("+ERROR: Unable to create -Save directory '$savedir'",
+            nprint("+ ERROR: Unable to create -Save directory '$savedir'",
                    "", ($mark->{'hostname'}, $mark->{'ip'}, $mark->{'displayname'}));
             exit;
         }


### PR DESCRIPTION
Some error messages were prefixed with `+ERROR`, but only `+ ERROR` are detected as error messages and redirected to stderr