### PR TITLE
refactor: reorder docker instructions to benefit from caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,23 @@
 FROM alpine:3.12
 
-LABEL version="2.1.6" \
+LABEL version="2.5.0" \
       author="Author Paul Sec (https://github.com/PaulSec), Nikto User https://github.com/drwetter" \
-      docker_build="docker build -t sullo/nikto:2.1.6 ." \
-      docker_run_basic="docker run --rm sullo/nikto:2.1.6 -h http://www.example.com" \
-      docker_run_advanced="docker run --rm -v $(pwd):/tmp sullo/nikto:2.1.6 -h http://www.example.com -o /tmp/out.json"
+      docker_build="docker build -t sullo/nikto:2.5.0 ." \
+      docker_run_basic="docker run --rm sullo/nikto:2.5.0 -h http://www.example.com" \
+      docker_run_advanced="docker run --rm -v $(pwd):/tmp sullo/nikto:2.5.0 -h http://www.example.com -o /tmp/out.json"
 
-COPY ["program/", "/nikto"]
-
-ENV  PATH=${PATH}:/nikto
-
-RUN echo 'Installing packages for Nikto.' \
-  && apk add --update --no-cache --virtual .build-deps \
+RUN echo 'Installing packages for Nikto.'
+RUN apk add --update --no-cache --virtual .build-deps \
      perl \
-     perl-net-ssleay \
-  && echo 'Creating the nikto group.' \
+     perl-net-ssleay
+
+RUN echo 'Creating the nikto group.' \
   && addgroup nikto \
   && echo 'Creating the nikto user.' \
-  && adduser -G nikto -g "Nikto user" -s /bin/sh -D nikto \
-  && echo 'Changing the ownership.' \
-  && chown -R nikto.nikto /nikto \
-  && echo 'Finishing image.'
+  && adduser -G nikto -g "Nikto user" -s /bin/sh -HD nikto
 
+ENV  PATH=${PATH}:/opt/nikto
 USER nikto
 
+COPY --chown=nikto:nikto ["program/", "/opt/nikto"]
 ENTRYPOINT ["nikto.pl"]


### PR DESCRIPTION
Docker treats every instruction as a layer and cache them. If anything change (for example content of ./program folder) docker rerun `COPY` layer and every layer after it.

Because of this behavior every time something in ./program folder was changed, docker had to rerun `apk add [...]` and other commands.

With current (changed) order only one layer (`COPY` layer) is rerun in case described above.