### PR TITLE
Bump Alpine version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.19
 
 LABEL version="2.5.0" \
       author="Author Paul Sec (https://github.com/PaulSec), Nikto User https://github.com/drwetter" \


### PR DESCRIPTION
Since support for Alpine 3.12 ended like two years ago, I suggest updating the base image in the Dockerfile to the current release Alpine 3.19.