### PR TITLE
Fix duplicate file extensions

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -1134,8 +1134,14 @@ sub general_config {
                 next;
             }
 
-            # Append format extension to prefix
-            my $file_name = $prefix . "." . $fmt;
+            # Append format extension to prefix only if not already present
+            my $file_name;
+            if ($prefix =~ /\.\Q$fmt\E$/i) {
+                $file_name = $prefix;
+            }
+            else {
+                $file_name = $prefix . "." . $fmt;
+            }
             $CLI{'files'}{$fmt} = $file_name;
         }
     }


### PR DESCRIPTION
Hi again :D

Tried to "sneak" in a question about this at the end of the PR description yesterday but i think you might have ovlooked :D

Also running in weird inconsistencies when runnign nikto with:

```bash
docker run --rm -v $(pwd):/tmp sullo/nikto -h http://www.example.com -o /tmp/out.json
```

which produces a `out.json.json` file.
Which seems to be incorrect as the help and man page state that the format should be infered.

Tried to fix it here and it seems to be working. Tested with the following combinations:

```bash
docker run --rm -v $(pwd):/tmp sullo/nikto -h http://www.example.com -o /tmp/out.json
docker run --rm -v $(pwd):/tmp sullo/nikto -h http://www.example.com -o /tmp/out -Format json
docker run --rm -v $(pwd):/tmp sullo/nikto -h http://www.example.com -o /tmp/out.json -Format json
```

(again disclosure: code written by LLM, have no perl knowledge :))