### PR TITLE
Clarify out-of-date message for non-git installations (#897)

### DIFF
--- a/program/plugins/nikto_core.plugin
+++ b/program/plugins/nikto_core.plugin
@@ -3557,7 +3557,9 @@ sub check_updates {
                 );
         }
         else {
-            nprint("+ Your Nikto installation is out of date.");
+            nprint(
+                "+ Your Nikto installation or DB files may be outdated. Update via your package manager, or install via git to stay current with the latest changes."
+                );
         }
         $VARIABLES{'deferout'} = $defer;
     }


### PR DESCRIPTION
Refs #897.

@sullo proposed updated wording in the issue thread for the non-git "out of date" path:

> Short term, maybe we update the message. If not git, we could change it to something like (suggestions welcome):
> _The installation or DB files are outdated. Update via your package manager. Installing via git is recommended to stay current with the latest changes._

This implements that suggestion with a small refinement: I changed "are outdated" to "may be outdated" because — as discussed in the thread — for users on the latest stable release tarball, the warning fires whenever there's been any commit to main since the tag, even if no new release has happened. Saying "may be" is more accurate than asserting it definitively.

The git-install path is unchanged.

Final wording:
> + Your Nikto installation or DB files may be outdated. Update via your package manager, or install via git to stay current with the latest changes.

Happy to tweak wording further if you'd prefer different phrasing.